### PR TITLE
Fixed #5 - Add usage if run "gelauto" with no command line options

### DIFF
--- a/bin/gelauto
+++ b/bin/gelauto
@@ -72,4 +72,8 @@ module Gelauto
   end
 end
 
-exit Gelauto::CLI.run(ARGV)
+if ARGF.argv.count == 0
+  puts "Example Usage: gelauto [ -- silent ] run [ --annotate ] [ -rbi ] $(find . -name '*.rb') -- bundle exec rspec spec/"
+else 
+  exit Gelauto::CLI.run(ARGV)
+end 


### PR DESCRIPTION
Code to implement usage if you type "gelauto" with no command line options.