### PR TITLE
Add 'extend T::Sig' to make 'srb tc' happy

### DIFF
--- a/bin/gelauto
+++ b/bin/gelauto
@@ -72,4 +72,8 @@ module Gelauto
   end
 end
 
-exit Gelauto::CLI.run(ARGV)
+if ARGF.argv.count == 0
+  puts "Example Usage: gelauto [ -- silent ] run [ --annotate ] [ -rbi ] $(find . -name '*.rb') -- bundle exec rspec spec/"
+else 
+  exit Gelauto::CLI.run(ARGV)
+end 

--- a/lib/gelauto/method_def.rb
+++ b/lib/gelauto/method_def.rb
@@ -24,6 +24,7 @@ module Gelauto
         components << "returns(#{return_types.to_sig})"
       end
 
+      "extend T::Sig"
       "sig { #{components.join('.')} }"
     end
 


### PR DESCRIPTION
Add 'extend T::Sig' wherever you are putting "sig" definitions to make 'srb tc' happy.