### PR TITLE
Fix T::Array, T::Hash, and T.any() types

### DIFF
--- a/lib/gelauto/array_type.rb
+++ b/lib/gelauto/array_type.rb
@@ -12,7 +12,7 @@ module Gelauto
 
     def to_sig
       if self[:elem].empty?
-        'T::Array'
+        'T::Array[T.untyped]'
       else
         "T::Array[#{self[:elem].to_sig}]"
       end

--- a/lib/gelauto/hash_type.rb
+++ b/lib/gelauto/hash_type.rb
@@ -15,7 +15,7 @@ module Gelauto
 
     def to_sig
       if self[:key].empty? && self[:value].empty?
-        'T::Hash'
+        'T::Hash[T.untyped, T.untyped]'
       else
         "T::Hash[#{self[:key].to_sig}, #{self[:value].to_sig}]"
       end

--- a/lib/gelauto/type_set.rb
+++ b/lib/gelauto/type_set.rb
@@ -53,8 +53,10 @@ module Gelauto
         'T.untyped'
       elsif sigs.size == 1
         sigs.first
+      elsif nilable
+        "T.nilable(T.any(#{sigs.join(', ')}))"
       else
-        "T.#{nilable ? 'nilable' : 'any'}(#{sigs.join(', ')})"
+        "T.any(#{sigs.join(', ')})"
       end
     end
   end

--- a/spec/gelauto_spec.rb
+++ b/spec/gelauto_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Gelauto do
@@ -20,6 +22,30 @@ describe Gelauto do
 
       aspect_ratio = get_indexed_method(img, :aspect_ratio)
       expect(aspect_ratio).to hand_back(Float)
+    end
+  end
+
+  context 'with Sorbet generic types' do
+    it 'uses T.nilable with T.any correctly' do
+      Gelauto.discover do
+        GelautoSpecs::Utility.safe_to_string(nil)
+        GelautoSpecs::Utility.safe_to_string(1.0)
+        GelautoSpecs::Utility.safe_to_string(2)
+      end
+
+      safe_to_string = get_indexed_method(GelautoSpecs::Utility, :safe_to_string)
+      expect(safe_to_string.to_sig).to include('input: T.nilable(T.any(Float, Integer))')
+      expect(safe_to_string.to_sig).to include('returns(String')
+    end
+
+    it 'uses T.Hash and T::Array with T.untyped correctly' do
+      Gelauto.discover do
+        GelautoSpecs::Utility.safe_get_keys({})
+      end
+
+      safe_get_keys = get_indexed_method(GelautoSpecs::Utility, :safe_get_keys)
+      expect(safe_get_keys.to_sig).to include('input: T::Hash[T.untyped, T.untyped]')
+      expect(safe_get_keys.to_sig).to include('returns(T::Array[T.untyped])')
     end
   end
 

--- a/spec/gelauto_spec.rb
+++ b/spec/gelauto_spec.rb
@@ -34,8 +34,7 @@ describe Gelauto do
       end
 
       safe_to_string = get_indexed_method(GelautoSpecs::Utility, :safe_to_string)
-      expect(safe_to_string.to_sig).to include('input: T.nilable(T.any(Float, Integer))')
-      expect(safe_to_string.to_sig).to include('returns(String')
+      expect(safe_to_string.to_sig).to eq('sig { params(input: T.nilable(T.any(Float, Integer))).returns(String) }')
     end
 
     it 'uses T.Hash and T::Array with T.untyped correctly' do
@@ -44,8 +43,7 @@ describe Gelauto do
       end
 
       safe_get_keys = get_indexed_method(GelautoSpecs::Utility, :safe_get_keys)
-      expect(safe_get_keys.to_sig).to include('input: T::Hash[T.untyped, T.untyped]')
-      expect(safe_get_keys.to_sig).to include('returns(T::Array[T.untyped])')
+      expect(safe_get_keys.to_sig).to eq('sig { params(input: T::Hash[T.untyped, T.untyped]).returns(T::Array[T.untyped]) }')
     end
   end
 

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -24,6 +24,24 @@ module GelautoSpecs
       Response.new(200, 'it worked!')
     end
   end
+
+  class Utility
+    def self.safe_to_string(input)
+      if input.nil?
+        ''
+      else
+        input.to_s
+      end
+    end
+
+    def self.safe_get_keys(input)
+      if input.nil?
+        []
+      else
+        input.keys
+      end
+    end
+  end
 end
 
 Gelauto.paths << __FILE__


### PR DESCRIPTION
This fixes a few annotations:

- `T::Array` alone is an error `Malformed type declaration. Generic class without type arguments T::Array`, must be `T::Array[T.untyped]` to be specified, at least
- Likewise, `T::Hash` alone is an error, must be `T::Hash[T.untyped, T.untyped]`
- Similarly, `T.nilable(String, Number)` is not valid; must be `T.nilable(T.any(String, Number))`