### PR TITLE
Do not add duplicate signatures to methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'sorbet-runtime'
+
 group :development do
   gem 'pry-byebug'
   gem 'rspec'

--- a/lib/gelauto/method_index.rb
+++ b/lib/gelauto/method_index.rb
@@ -68,11 +68,7 @@ module Gelauto
       mds = index[path]
 
       [].tap do |annotated|
-        last_class_index = nil
         lines.each_with_index do |line, idx|
-          if line.start_with?("class") || line.start_with?("module")
-            last_class_index = idx
-          end
           lineno = idx + 1
           md = mds[lineno]
 
@@ -81,11 +77,6 @@ module Gelauto
 
             indent = line[0...line.index(/[^\s]/)]
             annotated << "#{indent}#{md.to_sig}"
-
-            unless last_class_index.nil?
-              annotated.insert(last_class_index + 1, "#{indent}extend T::Sig")
-              last_class_index = nil
-            end
           end
 
           annotated << line

--- a/lib/gelauto/method_index.rb
+++ b/lib/gelauto/method_index.rb
@@ -68,13 +68,24 @@ module Gelauto
       mds = index[path]
 
       [].tap do |annotated|
+        last_class_index = nil
         lines.each_with_index do |line, idx|
+          if line.start_with?("class") || line.start_with?("module")
+            last_class_index = idx
+          end
           lineno = idx + 1
           md = mds[lineno]
 
           if md.is_a?(MethodDef)
+            next if lines[idx-1].include?('sig')
+
             indent = line[0...line.index(/[^\s]/)]
             annotated << "#{indent}#{md.to_sig}"
+
+            unless last_class_index.nil?
+              annotated.insert(last_class_index + 1, "#{indent}extend T::Sig")
+              last_class_index = nil
+            end
           end
 
           annotated << line

--- a/lib/gelauto/method_index.rb
+++ b/lib/gelauto/method_index.rb
@@ -78,9 +78,7 @@ module Gelauto
           lineno = idx + 1
           md = mds[lineno]
 
-          if md.is_a?(MethodDef)
-            next if sigs[idx]
-
+          if md.is_a?(MethodDef) && !sigs[idx]
             indent = line[0...line.index(/[^\s]/)]
             annotated << "#{indent}#{md.to_sig}"
           end

--- a/spec/gelauto_spec.rb
+++ b/spec/gelauto_spec.rb
@@ -56,6 +56,18 @@ describe Gelauto do
     end
   end
 
+  context 'does not double add sigs' do
+    before do
+      Gelauto.discover do
+        @request = GelautoSpecs::Request.new("Hello", "World")
+      end
+    end
+    it "does not double add sigs but adds new one" do
+      annotated = annotate(@request, :initialize, File.read('spec/support/client.rb'))
+      byebug
+    end
+  end
+
   context 'with nested generic types' do
     before do
       Gelauto.discover do

--- a/spec/gelauto_spec.rb
+++ b/spec/gelauto_spec.rb
@@ -59,12 +59,20 @@ describe Gelauto do
   context 'does not double add sigs' do
     before do
       Gelauto.discover do
-        @request = GelautoSpecs::Request.new("Hello", "World")
+        @request = GelautoSpecs::Request.new
+        @request.to_a("Hello", "World")
+        @request.to_s(100)
       end
     end
     it "does not double add sigs but adds new one" do
-      annotated = annotate(@request, :initialize, File.read('spec/support/client.rb'))
-      byebug
+      file = File.read('spec/support/annotated.rb')
+      expect(file.lines.count).to eq(17)
+      # does not add a signature to the method with an existing signature
+      annotated = annotate(@request, :to_a, file)
+      expect(annotated.lines.count).to eq(17)
+      # does add a signature to the method without a signature
+      annotated = annotate(@request, :to_s, file)
+      expect(annotated.lines.count).to eq(18)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,11 @@ RSpec.configure do |config|
         path, lineno = obj.method(method_name).source_location
         Gelauto.method_index.find(path, lineno)
       end
+
+      def annotate(obj, method_name, code)
+        path, _lineno = obj.method(method_name).source_location
+        Gelauto.method_index.annotate(path, code)
+      end
     end
   )
 end

--- a/spec/support/annotated.rb
+++ b/spec/support/annotated.rb
@@ -1,0 +1,17 @@
+require 'sorbet-runtime'
+
+module GelautoSpecs
+  class Request
+    extend T::Sig
+    sig { params(status: String, body: String).returns(T::Array[String]) }
+    def to_a(status, body)
+      [status, body]
+    end
+
+    def to_s(number)
+      number&.to_s
+    end
+  end
+end
+
+Gelauto.paths << __FILE__

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -1,3 +1,5 @@
+require 'sorbet-runtime'
+
 module GelautoSpecs
   class Response
     attr_reader :status, :body


### PR DESCRIPTION
Track which methods have existing signatures and do not double-add. 